### PR TITLE
reboot hung moonshot cartridges

### DIFF
--- a/moonshot/README.md
+++ b/moonshot/README.md
@@ -1,0 +1,10 @@
+# moonshot scripts
+
+1. reboot hung moonshot cartridges
+> The moonshot cartridges hang sometimes when rebooting. This script checks
+if a cartridge is powered on but not responding to a ping. It then reboots those
+cartridges.
+```
+./reboot_hung.sh
+# enter Administrator password
+```

--- a/moonshot/reboot_hung.sh
+++ b/moonshot/reboot_hung.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# for each moonshot cartridge
+#   find it in dns
+#   if ping fails
+#     check last task
+#     if last task exception or activity >30m ago,
+#       ilo: 
+#         if cartridge is powered on
+#           power cycle
+#         fi
+#     fi
+#   fi
+# fi
+#     
+
+echo -n "ILO admin password:"; read -s password; echo
+
+# we could ignore know dev/staging:
+# staging linux: t-[^-]*-ms-\(240\|280\|394\|395\)
+
+# alternative, get full hostname lists for vlans:
+#wintest_vlan=$(nmap -R -sL -Pn 10.49.58.6/24 | grep -o 't-[^ ]*test\.releng.mdc..mozilla.com')
+#test_vlan=$(nmap -R -sL -Pn 10.49.40.1/24 | grep -o 't-[^ ]*test\.releng.mdc..mozilla.com')
+
+# 14 chassis with 45 cartridges in each
+function find_no_ping() {
+  for I in {001..630}; do 
+    found=false
+    for group in linux64 w1064; do
+      if [[ $group == "w"* ]]; then
+        vnet="win"
+      else
+        vnet=""
+      fi
+      for dc in 1 2; do
+        (fqdn="t-${group}-ms-${I}.${vnet}test.releng.mdc${dc}.mozilla.com"
+        host ${fqdn} 2>&1 >/dev/null \
+          && (ping -q -c1 -w5 ${fqdn} 2>&1 >/dev/null \
+            || ( echo ${I} ${fqdn}; break ) ) &
+        )&
+      done
+    done
+  done
+  wait
+}
+export -f find_no_ping
+newlist=$(find_no_ping)
+echo "no ping response: ${newlist}"
+
+function is_older_than() {
+    timestamp="$(echo $1 | cut -d' ' -f4 | sed -e 's/T/ /')"
+    task_timestamp=$(date -u --date="$timestamp" +"%s")
+    compare_time=$(date -u --date="$2" +"%s")
+    [[ $task_timestamp -lt $compare_time ]]
+}
+export -f is_older_than
+
+worker_types=$(wget -q -O - https://queue.taskcluster.net/v1/provisioners/releng-hardware/worker-types/ | grep '\"workerType\"' | sed -e 's/.* "\([^"]*\)",$/\1/')
+export worker_types
+
+function check_last_task() {
+    fqdn=$1
+    printf "fqdn: $fqdn "
+
+    false && (if ! $(ping -q -c 1 -W 10 "${fqdn}" >/dev/null 2>&1 ); then
+        printf "no ping "
+    else
+        return 0
+    fi
+    )
+    hostname=${fqdn%%.*}
+    dc_name=$(echo $fqdn | sed -e "s/.*\(mdc1\|mdc2\).*/\1/")
+
+    try_first="gecko-t-linux-talos gecko-t-win10-64-hw"
+    worker_types="$try_first ${worker_types}"
+    found_worker=false
+    for workerType in $worker_types; do
+        taskId=$(wget -q -O - https://queue.taskcluster.net/v1/provisioners/releng-hardware/worker-types/${workerType}/workers/${dc_name}/${hostname} | grep 'taskId' | tail -1 | cut -d'"' -f4)
+        if [[ ${#taskId} -gt 0 ]]; then
+            found_worker=true
+            printf "\"%s\":" $taskId
+            break
+        fi
+    done
+    if ! $found_worker; then
+        printf "not found "
+        return 1
+    fi
+    #tc_url="https://tools.taskcluster.net/provisioners/releng-hardware/worker-types/${workerType}/workers/${dc_name}/${hostname}"
+
+    last_task=$(
+       wget -q -O - https://queue.taskcluster.net/v1/task/${taskId}/status \
+            | tr '\n' ' ' | grep -o "{[^{]*workerId.*${hostname}[^}]*}" \
+            | sed -e 's/[\t ]\+/ /g' -e 's/.*state.: .\([^"]*\)",.*started": "\([0-9:\.TZ\-]\+\)",\?\( "resolved":\( \)"\([0-9:\.TZ\-]\+\)"\)\?.*/\1 \2\4\5/'
+    )
+    last_task_status=$(echo $last_task | cut -d' ' -f1)
+    last_task_started=$(echo $last_task | cut -d' ' -f2)
+    last_task_ended=$(echo $last_task | cut -d' ' -f3)
+    tasks_found=$?
+    if [[ -z $last_task_ended ]]; then
+        last_task_activity=$last_task_started
+    else
+        last_task_activity=$last_task_ended
+    fi
+
+    #last_task_name=",\""$(wget -q -O - https://queue.taskcluster.net/v1/task/${taskId} | grep -A6 metadata | grep -o "name.*" | cut -d'"' -f3)"\""
+
+    old_tasks=false
+    if [[ $tasks_found -ne 0 ]]; then
+        printf "\"%s\"," "no tasks"
+    else
+        if is_older_than "$last_task_activity" "30 minutes ago"; then
+            printf "[\"[>%s]\",\"%s\"%s]," "30m" "${last_task_status}" "${last_task_started}" "${last_task_ended}" "${last_task_name}"
+            old_tasks=true
+        else
+            printf "[\"%s\"%s]," "${last_task}" "${last_task_name}"
+        fi
+    fi
+
+    if [[ "$last_task_status" == "exception" ]] || $old_tasks; then
+        printf "$last_task_status "
+        return 1
+    fi
+
+    return 0
+}
+export -f check_last_task
+
+>reboot_workers
+echo "${newlist}" \
+  | xargs --max-procs=1 -I{} bash -c '\
+  worker="{}";\
+  fqdn=$(echo $worker| cut -d\  -f2);\
+  check_last_task $fqdn \
+    || echo "${worker}" >> reboot_workers; \
+  echo;\
+  exit 0'
+echo ""
+missing=$(cat reboot_workers | cut -d\  -f1)
+echo "now will reboot: $missing"
+echo "${missing}" | xargs -P 4 -I {}  bash -c 'c={}; printf "$c"; echo -e "'$password'\n" | ./reboot_if_on.exp $(./translate_ms_name.sh $c 2>&1 | grep "\-\-hostname") | tee reboot.${c}.$(date +"%H:%M:%S").log; exit 0'

--- a/moonshot/reboot_if_on.exp
+++ b/moonshot/reboot_if_on.exp
@@ -1,0 +1,114 @@
+#!/usr/bin/expect --
+
+set (--password) ""
+
+proc named {args defaults} {
+    upvar 1 "" ""
+    array set "" $defaults
+    foreach {key value} $args {
+        if {![info exists ($key)]} {
+            error "bad option '$key', should be one of: [lsort [array names {}]]"
+        }
+        set ($key) $value
+    }
+}
+named $argv {--password "" --hostname "" --addr ""}
+
+if {$(--password) == ""} {
+    send_user "\rilo password: "
+    if {[gets stdin (--password)] <= 0} {
+        send_user "\rNo password entered.\n\r"
+    }
+}
+
+set password $(--password)
+set ilo $(--hostname)
+set node $(--addr)
+
+send_user "\rConnecting to $ilo to control $node ..."
+
+set force_conservative 1
+if {$force_conservative} {
+	set send_slow {1 .1}
+	proc send {ignore arg} {
+		sleep .1
+		exp_send -s -- $arg
+	}
+}
+
+set timeout 60
+spawn ssh -oStrictHostKeyChecking=no "$ilo"
+match_max 100000
+expect "password: "
+send -- "${password}\r"
+
+expect "hpiLO->"
+set waiting 6
+send_user "\rIs power on? "
+while { $waiting > 0 } {
+    sleep 5
+    set waiting [ expr $waiting - 1 ]
+    send -- "show node power $node\r"
+    expect {
+	"*On" { set waiting -1 }
+	"*Off" { send_user "." }
+    }
+}
+if { $waiting == -1 } {
+    send_user "\rpower is on. "
+} else {
+    send -- "exit\r"
+    exit 1
+}
+
+expect "hpiLO->"
+set retries 2
+while { $retries > 0 } {
+	send -- "set node power off force $node\r"
+	expect "hpiLO->"
+	set waiting 6
+	send_user "\rWaiting for power off "
+	while { $waiting > 0 } {
+	    sleep 5
+	    set waiting [ expr $waiting - 1 ]
+	    send -- "show node power $node\r"
+	    expect {
+		"*Off" { set waiting -1 }
+		"*On" { send_user "." }
+	    }
+	}
+    if { $waiting == -1 } { set retries 0 }
+    set retries [ expr $retries - 1 ]
+}
+send_user "\rPower is off"
+send_user "\n\r"
+sleep 5
+set retries 2
+while { $retries > 0 } {
+	send -- "set node power on $node\r"
+	expect "hpiLO->"
+	set waiting 6
+	send_user "\rWaiting for power on "
+	while { $waiting > 0 } {
+	    sleep 5
+	    set waiting [ expr $waiting - 1 ]
+	    send -- "show node power $node\r"
+	    expect {
+		"*On" { set waiting -1 }
+		"*Off" { send_user "." }
+	    }
+	}
+    if { $waiting == -1 } { set retries 0 }
+    set retries [ expr $retries - 1 ]
+}
+send_user "\rPower is on"
+send_user "\n\r"
+expect "hpiLO->"
+send -- "exit\r"
+expect eof
+send_user "\rFinished $ilo $node"
+if { $status == 0 } {
+  exit 0
+} else {
+  exit 1
+}


### PR DESCRIPTION
this is the script I've been running, with the Administrator password (in gpg repo), to reboot the hung moonshot cartridges.

I run it every day or two, depending on the number of active workers and the queues (if queues are high or many are missing, I'll run it even if only a day has passed since I last ran it):
https://earthangel-b40313e5.influxcloud.net/d/slXwf4emz/workers?orgId=1&refresh=1m&from=now-7d&to=now&var-provisioner=releng-hardware&var-workerType=gecko-t-linux-talos&var-workerType=gecko-t-win10-64-hw