### PR TITLE
ubuntu1804 provisioning

### DIFF
--- a/moonshot/hostname_to_cart.sh
+++ b/moonshot/hostname_to_cart.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+shopt -s extglob
+declare -i I
+
+: ${1?"Usage: $0 hostname[s]/host_number[s]"}
+
+declare -A chassis
+
+for arg in $@; do
+    I=${arg##+(0)}
+    if [[ $I -gt 630 ]]; then
+        c=$(( ( ( I - 1 ) - 30 ) / 45 + 2 ))
+        n=$(( ( ( I - 1 ) - 630 ) % 45 + 1 ))
+    elif [[ $I -gt 615 ]]; then
+        c=$(( ( ( I - 1 ) - 15 ) / 45 + 1 - 13 ))
+        n=$(( ( ( I - 1 ) - 615 ) % 45 + 1 + 30 ))
+    elif [[ $I -gt 300 ]]; then
+        c=$(( ( ( I - 1 ) + 15 ) / 45 + 1 ))
+        n=$(( ( ( I - 1 ) + 15 ) % 45 + 1 ))
+    else
+        c=$(( ( I - 1 ) / 45 + 1 ))
+        n=$(( ( I - 1 ) % 45 + 1 ))
+    fi
+    # echo $c $n
+    chassis[$c]+="$n,"
+done
+
+for c in ${!chassis[@]}; do
+    if [[ $c -gt 7 ]]; then
+        dc="mdc2"
+    else
+        dc="mdc1"
+    fi
+    echo moon-chassis-${c}.inband.releng.${dc}.mozilla.com C${chassis[$c]%%,}N1
+done

--- a/moonshot/reimage_1804.exp
+++ b/moonshot/reimage_1804.exp
@@ -1,0 +1,136 @@
+#!/usr/bin/expect --
+
+proc named {args defaults} {
+    upvar 1 "" ""
+    array set "" $defaults
+    foreach {key value} $args {
+        if {![info exists ($key)]} {
+            error "bad option '$key', should be one of: [lsort [array names {}]]"
+        }
+        set ($key) $value
+    }
+}
+named $argv {--chassis "" --node "" --boot-params ""}
+
+set chassis $(--chassis)
+set node $(--node)
+set boot_params $(--boot-params)
+
+send_user "\rConnecting to $chassis to control $node ..."
+
+set force_conservative 1
+if {$force_conservative} {
+	set send_slow {1 .1}
+	proc send {ignore arg} {
+		sleep .1
+		exp_send -s -- $arg
+	}
+}
+
+set timeout 120
+spawn ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 -oCiphers=+aes128-cbc -oStrictHostKeyChecking=no "$chassis"
+match_max 100000
+sleep 5
+expect "hpiLO->"
+send -- "set node bootonce pxe $node\r"
+expect "bootonce: PXE"
+expect "hpiLO->"
+set retries 2
+while { $retries > 0 } {
+	send -- "set node power off force $node\r"
+	expect "hpiLO->"
+	set waiting 6
+	send_user "\rWaiting for power off "
+	while { $waiting > 0 } {
+	    sleep 5
+	    set waiting [ expr $waiting - 1 ]
+	    send -- "show node power $node\r"
+	    expect {
+		"*Off" { set waiting -1 }
+		"*On" { send_user "." }
+	    }
+	}
+    if { $waiting == -1 } { set retries 0 }
+    set retries [ expr $retries - 1 ]
+}
+send_user "\rPower is off"
+send_user "\n\r"
+sleep 0.5
+set retries 2
+while { $retries > 0 } {
+	send -- "set node power on $node\r"
+	expect "hpiLO->"
+	set waiting 6
+	send_user "\rWaiting for power on "
+	while { $waiting > 0 } {
+	    sleep 5
+	    set waiting [ expr $waiting - 1 ]
+	    send -- "show node power $node\r"
+	    expect {
+		"*On" { set waiting -1 }
+		"*Off" { send_user "." }
+	    }
+	}
+    if { $waiting == -1 } { set retries 0 }
+    set retries [ expr $retries - 1 ]
+}
+send_user "\rPower is on"
+send_user "\n\r"
+sleep 0.2
+expect "hpiLO->"
+send -- "connect node vsp $node\r"
+send_user "\rcheck vsp\r"
+expect "Virtual Serial Port Active: "
+send_user "\n\r"
+set timeout -1
+send_user "\rWaiting for boot menu on $node "
+for {set NUM 0} {$NUM <= 5} {incr NUM} {
+    send -- " "
+    send_user "."
+    sleep 5
+}
+set timeout -1
+sleep 2
+
+#expect "Starting drivers. Please wait, this may take a few moments....\r"
+#expect "Fetching Netboot Image\r"
+
+expect "Press 'e' to edit the selected item, or 'c' for a command prompt."
+# "Chainload Grub on EFI System Partition"
+# "Install Ubuntu 18.04 LTS x86_64 on moonshot"
+# "Install Ubuntu 16.04.0 LTS x86_64 on moonshot"
+
+# cursor down once
+send -- "\[B"
+expect "Install Ubuntu"
+send -- "e"
+set timeout 60
+sleep 1
+expect "Press Ctrl-x to start"
+expect "initrd.gz"
+send -- "\[B"
+sleep 0.5
+send -- "\[B"
+sleep 0.5
+send -- "\[B"
+sleep 0.5
+# cursor left to end of previous line
+send -- "\[D"
+sleep 1
+# add a space at the end of line
+send -- " "
+sleep 0.5
+# add parameters
+send -- "$boot_params"
+sleep 5
+# "Ctrl-x to start"
+send -- ""
+send_user "\rInitiated boot ..."
+sleep 60
+# exit virtual serial port
+send -- "("
+expect "hpiLO->"
+send -- "exit\r"
+expect eof
+send_user "\rFinished $chassis $node"
+

--- a/moonshot/reimage_1804.sh
+++ b/moonshot/reimage_1804.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+USAGE="Usage: $0 chassis node1 node2 ..\nExample: '\$ ./$0 7 {1..3}  # reinstall chassis 7 nodes 1-3\n\n"
+if [ "$#" == "0" ]; then
+    printf "$USAGE"
+    exit 1
+fi
+
+chassis=$1
+hostname=moon-chassis-${chassis}.inband.releng.mdc$(( chassis/8+1 )).mozilla.com
+shift
+
+# if we need to drop some secrets through the preseed, we could add them:
+boot_params=""
+
+for node in $@; do
+    echo $node
+    ./reimage_1804.exp --chassis relops@${hostname} --node C1N$node --boot-params "$boot_params" \
+        | tee ${0%%.sh}.$chassis.$node.$(date +"%H:%M:%S").log
+done

--- a/moonshot/reimage_1804.sh
+++ b/moonshot/reimage_1804.sh
@@ -15,6 +15,6 @@ boot_params=""
 
 for node in $@; do
     echo $node
-    ./reimage_1804.exp --chassis relops@${hostname} --node C1N$node --boot-params "$boot_params" \
+    ./reimage_1804.exp --chassis relops@${hostname} --node c${node}n1 --boot-params "$boot_params" \
         | tee ${0%%.sh}.$chassis.$node.$(date +"%H:%M:%S").log
 done

--- a/moonshot/reimage_loop.sh
+++ b/moonshot/reimage_loop.sh
@@ -1,0 +1,3 @@
+echo -n "ILO admin password:"; read -s password; echo
+echo -n "kickstart password:"; read -s kickstart; echo
+for c in $@; do echo $c; echo -e "$password\n$kickstart\n" | ./reimage_watch.exp $(./translate_ms_name.sh $c 2>&1 | grep "\-\-hostname"); done | tee reimage.$(date +"%H:%M:%S").log

--- a/moonshot/reimage_watch.exp
+++ b/moonshot/reimage_watch.exp
@@ -75,7 +75,10 @@ while { $retries > 0 } {
 }
 send_user "\rPower is off"
 send_user "\n\r"
-sleep 0.5
+send -- "set node bootonce pxe $node\r"
+expect "bootonce: PXE"
+expect "hpiLO->"
+sleep 5
 set retries 2
 while { $retries > 0 } {
 	send -- "set node power on $node\r"
@@ -109,8 +112,7 @@ for {set NUM 0} {$NUM <= 5} {incr NUM} {
     send_user "."
     sleep 5
 }
-set timeout -1
-sleep 2
+set timeout 300
 
 #expect "Starting drivers. Please wait, this may take a few moments....\r"
 #expect "Fetching Netboot Image\r"
@@ -144,11 +146,10 @@ sleep 4
 send -- "$kickstart"
 sleep 5
 send -- ""
-send_user "\rInitiated boot ..."
-sleep 8
-send -- "("
+sleep 60
+#send -- "("
 expect "hpiLO->"
-send -- "exit\r"
-expect eof
-send_user "\rFinished $ilo $node"
+#send -- "exit\r"
+#expect eof
+#send_user "\rFinished $ilo $node"
 

--- a/moonshot/translate_ms_name.sh
+++ b/moonshot/translate_ms_name.sh
@@ -3,6 +3,12 @@
 hostname_prefix="t-linux64-ms-"
 workerType="gecko-t-linux-talos"
 
+if [[ "${1}" -eq "win" ]]; then
+hostname_prefix="T-W1064-MS-"
+workerType="gecko-t-win10-64-hw"
+	shift
+fi
+
 : ${1?"Usage: $0 hostname[s]"}
 
 for c in {1..14}; do
@@ -14,7 +20,7 @@ for c in {1..14}; do
         nstart=$(( nstart - 15 ))
     fi
     # For linux, we are using the first 15 on each chassis.
-    for i in {1..15}; do
+    for i in {1..45}; do
         I=$(( nstart + i ))
         if ! (( c % 7 )) && (( i > 10 )); then
             break


### PR DESCRIPTION
* I used expect version 5.45.4
The releng jumphosts have expect version 5.44.1.15 and I've used that just as well.
* you'll need the relops ssh key set up. I have this in my .ssh/config:
```
Host moon-chassis-??.inband.releng.mdc?.mozilla.com moon-chassis-?.inband.releng.mdc?.mozilla.com
    User relops
    IdentityFile ~/.ssh/id_rsa_relops_2020-05-07
    KexAlgorithms +diffie-hellman-group14-sha1
    Ciphers +aes128-cbc
```

Example run:
```
./reimage_1804.sh 7 {1..3}  # to install ubuntu 1804 onto chassis 7 nodes 1-3
# it then executes like:
./reimage_1804.exp --chassis relops@moon-chassis-7.inband.releng.mdc1.mozilla.com --node C1N1 --boot-params ""
...
```