### PR TITLE
moonshot errata 999

### DIFF
--- a/moonshot/oneshot_linux.sh
+++ b/moonshot/oneshot_linux.sh
@@ -221,13 +221,13 @@ else
   ) 200>"$LOCK_FILE"
 
   # sleep to allow the host to finish installation
-  # 18.04 takes longer, so sleep 18 minutes; otherwise 10 minutes
+  # 18.04 takes longer, so sleep 18 minutes; otherwise 14 minutes
   if [[ "$OS_VERSION" == "1804" ]]; then
     echo "Sleeping 18 minutes to allow host to finish OS installation (18.04 takes longer)..."
     countdown 1080
   else
-    echo "Sleeping 10 minutes to allow host to finish OS installation..."
-    countdown 600
+    echo "Sleeping 14 minutes to allow host to finish OS installation..."
+    countdown 840
   fi
   echo "Sleep complete."
 fi

--- a/moonshot/reimage_2404.exp
+++ b/moonshot/reimage_2404.exp
@@ -105,7 +105,7 @@ sleep 10
 
 # exit virtual serial port
 #  `Press 'ESC (' to return to the CLI Session.`
-send -- "("
+exp_send -- "\033("
 expect "hpiLO->"
 send -- "exit\r"
 expect eof

--- a/moonshot/reimage_2404.exp
+++ b/moonshot/reimage_2404.exp
@@ -94,11 +94,11 @@ expect "netboot.xyz"
 expect "booting default..."
 sleep 5
 # press down key 3 times and then press enter
-send -- "\[B"
+exp_send -- "\033\[B"
 sleep 1
-send -- "\[B"
+exp_send -- "\033\[B"
 sleep 1
-send -- "\[B"
+exp_send -- "\033\[B"
 sleep 1
 send -- "\r"
 sleep 10


### PR DESCRIPTION
- deliver.sh: increase 2404 sleep time after reimaging before converging
- reimage_2404: fix ANSI escape sequence for down arrow key 
- reimage_2404: fix VSP exit sequence to include ESC prefix 